### PR TITLE
Uniform buffers

### DIFF
--- a/VulkanProject/UnidormBufferObject.hpp
+++ b/VulkanProject/UnidormBufferObject.hpp
@@ -1,7 +1,9 @@
 #include <glm/glm.hpp>
 
+// See alignment requirements in specification
+// (https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-layout)
 struct UniformBufferObject {
-    glm::mat4 model;
-    glm::mat4 view;
-    glm::mat4 proj;
+    alignas(16) glm::mat4 model;
+    alignas(16) glm::mat4 view;
+    alignas(16) glm::mat4 proj;
 };

--- a/VulkanProject/UnidormBufferObject.hpp
+++ b/VulkanProject/UnidormBufferObject.hpp
@@ -1,0 +1,7 @@
+#include <glm/glm.hpp>
+
+struct UniformBufferObject {
+    glm::mat4 model;
+    glm::mat4 view;
+    glm::mat4 proj;
+};

--- a/VulkanProject/VulkanProject.vcxproj
+++ b/VulkanProject/VulkanProject.vcxproj
@@ -142,6 +142,7 @@
     <None Include="shaders\shader.vert" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="UnidormBufferObject.hpp" />
     <ClInclude Include="Vertex.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VulkanProject/VulkanProject.vcxproj.filters
+++ b/VulkanProject/VulkanProject.vcxproj.filters
@@ -34,5 +34,8 @@
     <ClInclude Include="Vertex.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="UnidormBufferObject.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/VulkanProject/shaders/shader.vert
+++ b/VulkanProject/shaders/shader.vert
@@ -1,11 +1,17 @@
 #version 450
 
+layout(binding = 0) uniform UniformBufferObject {
+    mat4 model;
+    mat4 view;
+    mat4 proj;
+} ubo;
+
 layout(location = 0) in vec2 inPosition;
 layout(location = 1) in vec3 inColor;
 
 layout(location = 0) out vec3 fragColor;
 
 void main() {
-    gl_Position = vec4(inPosition, 0.0, 1.0);
+    gl_Position = ubo.proj * ubo.view * ubo.model * vec4(inPosition, 0.0, 1.0);
     fragColor = inColor;
 }


### PR DESCRIPTION

### Description
The project now uses uniform buffer objects (UBOs) passed to the vertex shader through descriptor sets (as many as MAX_FRAMES_IN_FLIGHT). UBOs have these variables:
- model: it produces a rotation (90º per second).
- view: it changes from world coordinates to camera coordinates.
- proj: it changes from camera coordinates to screen coordinates.
The process uses descriptor set layouts, a descriptor pool and descriptor sets.

### Main changes
- UniformBufferObject struct created, vertex shaders now receives a similar struct as uniform input.
- Graphics pipeline layout now has the descriptor set layout.
- Command buffer recording binds descriptor sets to use them in the draw command.

### Possible improvements
- Use push constants for uniform variables

