### PR TITLE
Use SDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ mono_crash.*
 # SpirV binaries
 *.spv
 
-[Tt]hird-[Pp]arty/
+[Tt]hird-[Pp]arty/*
+!third-party/licenses/
 
 # Build results
 [Bb]uild/

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ mono_crash.*
 # SpirV binaries
 *.spv
 
+[Tt]hird-[Pp]arty/
+
 # Build results
 [Bb]uild/
 [Dd]ebug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,13 @@ set(SOURCES
     ${SOURCE_CODE_PATH}/Window.cpp
 )
 
-set(THIRD_PARTY_LIB_PATH "C:/development/cpp")
-
 #------------------------------
 # BUILD THE LIBRARY
 if(BUILD_LIBRARY)
     add_library(${PROJECT_NAME} STATIC ${SOURCES})
 
     # Build library outside the project
-    set(LIBRARY_OUTPUT_DIRECTORY "${THIRD_PARTY_LIB_PATH}/${PROJECT_NAME}")
+    set(LIBRARY_OUTPUT_DIRECTORY "C:/development/cpp/${PROJECT_NAME}")
     set_target_properties(${PROJECT_NAME} PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY "${LIBRARY_OUTPUT_DIRECTORY}"
     )
@@ -69,18 +67,20 @@ endif()
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # EXTERNAL LIBRARIES
 
+set(THIRD_PARTY_LIB_PATH "${CMAKE_SOURCE_DIR}/third-party")
+
 add_subdirectory(third-party/SDL EXCLUDE_FROM_ALL)
 
 find_package(Vulkan REQUIRED)
 target_include_directories(${PROJECT_NAME} PRIVATE
-    ${THIRD_PARTY_LIB_PATH}/glfw-3.4.bin.WIN64/include
+    ${THIRD_PARTY_LIB_PATH}/glfw/include
     ${THIRD_PARTY_LIB_PATH}/glm
-    ${THIRD_PARTY_LIB_PATH}/stb-master
+    ${THIRD_PARTY_LIB_PATH}/stb
     ${THIRD_PARTY_LIB_PATH}/tiny_obj_loader/include
 )
 
 target_link_libraries(${PROJECT_NAME}
-    ${THIRD_PARTY_LIB_PATH}/glfw-3.4.bin.WIN64/lib-vc2022/glfw3.lib
+    ${THIRD_PARTY_LIB_PATH}/glfw/lib-vc2022/glfw3.lib
     Vulkan::Vulkan
     SDL3::SDL3
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(PROJECT_NAME "VulkanProject")
 project(${PROJECT_NAME})
 
 set(CMAKE_CXX_STANDARD 17)
-set(BUILD_LIBRARY true)
+set(BUILD_LIBRARY false)
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # PROJECT FILES
@@ -60,11 +60,16 @@ if(BUILD_LIBRARY)
 #------------------------------
 # BUILD THE EXECUTABLE
 else()
+    # Change the output to have the SDL .dll automatically inside the .exe directory
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<CONFIGURATION>")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<CONFIGURATION>")
     add_executable(${PROJECT_NAME} ${SOURCES})
 endif()
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # EXTERNAL LIBRARIES
+
+add_subdirectory(third-party/SDL EXCLUDE_FROM_ALL)
 
 find_package(Vulkan REQUIRED)
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -77,4 +82,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME}
     ${THIRD_PARTY_LIB_PATH}/glfw-3.4.bin.WIN64/lib-vc2022/glfw3.lib
     Vulkan::Vulkan
+    SDL3::SDL3
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,14 +74,12 @@ add_subdirectory(third-party/SDL EXCLUDE_FROM_ALL)
 
 find_package(Vulkan REQUIRED)
 target_include_directories(${PROJECT_NAME} PRIVATE
-    ${THIRD_PARTY_LIB_PATH}/glfw/include
     ${THIRD_PARTY_LIB_PATH}/glm
     ${THIRD_PARTY_LIB_PATH}/stb
     ${THIRD_PARTY_LIB_PATH}/tiny_obj_loader/include
 )
 
 target_link_libraries(${PROJECT_NAME}
-    ${THIRD_PARTY_LIB_PATH}/glfw/lib-vc2022/glfw3.lib
     Vulkan::Vulkan
     SDL3::SDL3
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     ${SOURCE_CODE_PATH}/AppTime.cpp
     ${SOURCE_CODE_PATH}/CommandManager.cpp
     ${SOURCE_CODE_PATH}/Device.cpp
+    ${SOURCE_CODE_PATH}/eventManagement.cpp
     ${SOURCE_CODE_PATH}/FirstPassPipeline.cpp
     ${SOURCE_CODE_PATH}/imageUtils.cpp
     ${SOURCE_CODE_PATH}/Model.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,8 @@ if(BUILD_LIBRARY)
 # BUILD THE EXECUTABLE
 else()
     # Change the output to have the SDL .dll automatically inside the .exe directory
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<CONFIGURATION>")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<CONFIGURATION>")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
     add_executable(${PROJECT_NAME} ${SOURCES})
 endif()
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The project will also serve as Bachelor's Degree Final Project, as the intention
 
 The project depends on the following libraries used externally:
 
-- **[GLFW](https://www.glfw.org/)**
-   - For window creation and other OS dependent operations.
-   - **License**: zlib/libpng License.
+- **[SDL](https://www.libsdl.org/)**
+   - For window creation and other OS dependent operations like events.
+   - **License**: zlib License.
 
 - **[GLM](https://github.com/g-truc/glm)**
    - For the maths behind the vertex of the models and matrices like `model`, `view` and `projection`.
@@ -19,7 +19,7 @@ The project depends on the following libraries used externally:
    - **License**: Public Domain or MIT License.
 
 - **[tinyobjloader](https://github.com/tinyobjloader/tinyobjloader)**
-   - For obj. model loading.
+   - For .obj model loading.
    - **License**: MIT License.
 
 ## License:

--- a/VulkanProject/src/VulkanApplication.hpp
+++ b/VulkanProject/src/VulkanApplication.hpp
@@ -27,6 +27,7 @@
 #include "Model.hpp"
 #include "Texture.hpp"
 #include "AppTime.hpp"
+#include "eventManagement.hpp"
 
 
 const uint32_t WIDTH = 800;
@@ -196,7 +197,7 @@ private:
 		SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO);
 
 		window.create("Vulkan Render Engine", WIDTH, HEIGHT);
-		window.subscribeFramebufferResizedEvent([this](int width, int height) {
+		addEventSubscriber(SDL_EVENT_WINDOW_RESIZED, [this](SDL_Event e) {
 			framebufferResized = true;
 			});
 	}
@@ -858,6 +859,7 @@ private:
 
 		while (!window.shouldClose()) {
 			// PROCESS INPUT
+			pollEvents();
 
 			// DRAW
 			drawFrame();

--- a/VulkanProject/src/VulkanApplication.hpp
+++ b/VulkanProject/src/VulkanApplication.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-//#include <vulkan/vulkan.h>
-#define GLFW_INCLUDE_VULKAN
-#include <GLFW/glfw3.h>
+#include <vulkan/vulkan.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_vulkan.h>
 
 #include <iostream>
 #include <stdexcept>
@@ -192,9 +192,10 @@ private:
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void initWindow() {
-		glfwInit();
 
-		window.create<void>(this, WIDTH, HEIGHT);
+		SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO);
+
+		window.create("Vulkan Render Engine", WIDTH, HEIGHT);
 		window.subscribeFramebufferResizedEvent([this](int width, int height) {
 			framebufferResized = true;
 			});
@@ -311,11 +312,11 @@ private:
 	}
 
 	std::vector<const char*> getRequiredExtensions() {
-		uint32_t glfwExtensionCount = 0;
-		const char** glfwExtensions;
-		glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
+		uint32_t sdlExtensionCount = 0;
+		const char* const* sdlExtensions;
+		sdlExtensions = SDL_Vulkan_GetInstanceExtensions(&sdlExtensionCount);
 
-		std::vector<const char*> extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
+		std::vector<const char*> extensions(sdlExtensions, sdlExtensions + sdlExtensionCount);
 
 		// add debug utils extension (if debugging)
 		if (enableValidationLayers)
@@ -415,7 +416,7 @@ private:
 		VkExtent2D extent = {0, 0};
 		while(extent.width == 0 || extent.height == 0){
 			extent = window.getFramebufferSize();
-			glfwWaitEvents();
+			SDL_WaitEvent(NULL);
 		}
 
 		vkDeviceWaitIdle(device.get());
@@ -856,7 +857,9 @@ private:
 	void mainLoop() {
 
 		while (!window.shouldClose()) {
-			glfwPollEvents();
+			// PROCESS INPUT
+
+			// DRAW
 			drawFrame();
 		}
 
@@ -1004,7 +1007,7 @@ private:
 
 		window.cleanup();
 
-		glfwTerminate();
+		SDL_Quit();
 	}
 
 	void cleanupRenderImages() {

--- a/VulkanProject/src/Window.cpp
+++ b/VulkanProject/src/Window.cpp
@@ -1,26 +1,42 @@
 #include "Window.hpp"
 
+#include <SDL3/SDL_vulkan.h>
+
 #include <vector>
 #include <stdexcept>
 
-#include "VulkanApplication.hpp"
 
+bool framebufferResizeCallback(void* userdata, SDL_Event* event) {
+	if (event->type != SDL_EVENT_WINDOW_RESIZED) return true;
 
-void Window::framebufferResizeCallback(GLFWwindow* involvedWindow, int width, int height) {
-	auto window = reinterpret_cast<Window*>(glfwGetWindowUserPointer(involvedWindow));
+	auto window = reinterpret_cast<Window*>(userdata);
+
+	int width, height;
+	SDL_GetWindowSize(window->window, &width, &height);
+
 	for (auto& update : window->framebufferResizeSubscribers)
 		update(width, height);
+
+	return true;
+}
+
+void Window::create(char* title, int width, int height) {
+	window = SDL_CreateWindow(title,
+		width, height, SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
+
+	// Add subscribers
+	SDL_AddEventWatch(framebufferResizeCallback, this);
 }
 
 void Window::createSurface(VkInstance vulkanInstance, VkSurfaceKHR* surface) {
-	if (glfwCreateWindowSurface(vulkanInstance, window, nullptr, surface) != VK_SUCCESS) {
+	if (!SDL_Vulkan_CreateSurface(window, vulkanInstance, nullptr, surface)) {
 		throw std::runtime_error("failed to create window surface");
 	}
 }
 
 VkExtent2D Window::getFramebufferSize() {
 	int width, height;
-	glfwGetFramebufferSize(window, &width, &height);
+	SDL_GetWindowSize(window, &width, &height);
 
 	return VkExtent2D{
 		static_cast<uint32_t>(width),
@@ -29,9 +45,11 @@ VkExtent2D Window::getFramebufferSize() {
 }
 
 int Window::shouldClose() {
-	return glfwWindowShouldClose(window);
+	SDL_Event event;
+	SDL_PollEvent(&event);
+	return event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED;
 }
 
 void Window::cleanup() {
-	glfwDestroyWindow(window);
+	SDL_DestroyWindow(window);
 }

--- a/VulkanProject/src/Window.cpp
+++ b/VulkanProject/src/Window.cpp
@@ -5,27 +5,15 @@
 #include <vector>
 #include <stdexcept>
 
+#include "eventManagement.hpp"
 
-bool framebufferResizeCallback(void* userdata, SDL_Event* event) {
-	if (event->type != SDL_EVENT_WINDOW_RESIZED) return true;
-
-	auto window = reinterpret_cast<Window*>(userdata);
-
-	int width, height;
-	SDL_GetWindowSize(window->window, &width, &height);
-
-	for (auto& update : window->framebufferResizeSubscribers)
-		update(width, height);
-
-	return true;
-}
 
 void Window::create(char* title, int width, int height) {
 	window = SDL_CreateWindow(title,
 		width, height, SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
 
-	// Add subscribers
-	SDL_AddEventWatch(framebufferResizeCallback, this);
+	// Subscribe to close window event
+	addEventSubscriber(SDL_EVENT_WINDOW_CLOSE_REQUESTED, [this](SDL_Event e) {closeRequested = true; });
 }
 
 void Window::createSurface(VkInstance vulkanInstance, VkSurfaceKHR* surface) {
@@ -42,12 +30,6 @@ VkExtent2D Window::getFramebufferSize() {
 		static_cast<uint32_t>(width),
 		static_cast<uint32_t>(height)
 	};
-}
-
-int Window::shouldClose() {
-	SDL_Event event;
-	SDL_PollEvent(&event);
-	return event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED;
 }
 
 void Window::cleanup() {

--- a/VulkanProject/src/Window.hpp
+++ b/VulkanProject/src/Window.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#define GLFW_INCLUDE_VULKAN
-#include <GLFW/glfw3.h>
+#include <vulkan/vulkan.h>
+#include <SDL3/SDL.h>
 
 #include <functional>
 
@@ -12,21 +12,14 @@ public:
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// GETTERS AND SETTERS
 
-	GLFWwindow* get() { return window; }
+	SDL_Window* get() { return window; }
 
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// METHODS
 	
-	template <typename F>
-	void create(void* userPointer, int width, int height) {
-		glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-
-		window = glfwCreateWindow(width, height, "Vulkan", nullptr, nullptr);
-		glfwSetWindowUserPointer(window, this);
-		glfwSetFramebufferSizeCallback(window, framebufferResizeCallback);
-	}
+	void create(char* title, int width, int height);
 
 	template <typename F>
 	void subscribeFramebufferResizedEvent(F updateFunction) {
@@ -47,12 +40,12 @@ private:
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// CLASS MEMBERS
 
-	GLFWwindow* window;
+	SDL_Window* window;
 	std::vector<std::function<void(int, int)>> framebufferResizeSubscribers;
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// METHODS
 
-	static void framebufferResizeCallback(GLFWwindow* window, int width, int height);
+	friend bool framebufferResizeCallback(void* userdata, SDL_Event* event);
 
 };

--- a/VulkanProject/src/Window.hpp
+++ b/VulkanProject/src/Window.hpp
@@ -13,7 +13,7 @@ public:
 	// GETTERS AND SETTERS
 
 	SDL_Window* get() { return window; }
-
+	bool shouldClose() { return closeRequested; }
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -21,17 +21,10 @@ public:
 	
 	void create(char* title, int width, int height);
 
-	template <typename F>
-	void subscribeFramebufferResizedEvent(F updateFunction) {
-		framebufferResizeSubscribers.push_back(updateFunction);
-	}
-
 	void createSurface(VkInstance vulkanInstance, VkSurfaceKHR* surface);
 
 	// Get the resolution in pixels
 	VkExtent2D getFramebufferSize();
-
-	int shouldClose();
 
 	void cleanup();
 
@@ -41,11 +34,6 @@ private:
 	// CLASS MEMBERS
 
 	SDL_Window* window;
-	std::vector<std::function<void(int, int)>> framebufferResizeSubscribers;
-
-	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// METHODS
-
-	friend bool framebufferResizeCallback(void* userdata, SDL_Event* event);
+	bool closeRequested;
 
 };

--- a/VulkanProject/src/eventManagement.cpp
+++ b/VulkanProject/src/eventManagement.cpp
@@ -1,0 +1,26 @@
+#include "eventManagement.hpp"
+
+#include <map>
+#include <vector>
+
+
+std::map<EventType, std::vector<EventSubscriber>> subscribers;
+
+void addEventSubscriber(EventType type, EventSubscriber subscriber) {
+	subscribers[type].push_back(subscriber);
+}
+
+static void updateSubscribers(SDL_Event event) {
+	std::vector<EventSubscriber> callbacks = subscribers[event.type];
+	for (auto& update : callbacks)
+		update(event);
+
+}
+
+void pollEvents() {
+
+	SDL_Event event;
+	while (SDL_PollEvent(&event)) {
+		updateSubscribers(event);
+	}
+}

--- a/VulkanProject/src/eventManagement.hpp
+++ b/VulkanProject/src/eventManagement.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <SDL3/SDL_events.h>
+
+#include <functional>
+
+
+using EventSubscriber = std::function<void(SDL_Event)>;
+using EventType = Uint32;
+
+void addEventSubscriber(EventType type, EventSubscriber subscriber);
+
+void pollEvents();

--- a/third-party/licenses/Happy-Bunny-License
+++ b/third-party/licenses/Happy-Bunny-License
@@ -1,0 +1,21 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+Restrictions:
+ By making use of the Software for military purposes, you choose to make a
+ Bunny unhappy.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/third-party/licenses/MIT-License
+++ b/third-party/licenses/MIT-License
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third-party/licenses/Zlib-License
+++ b/third-party/licenses/Zlib-License
@@ -1,0 +1,15 @@
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
### Description

Use the SDL library instead of GLFW. Window creation and event handling is now managed with SDL.

### Main changes

- Add license directory for all the third-party libraries and resources used in the project.
- `eventManagement` files offer event handling with the observer pattern.
- Now `Window` class:
  - uses SDL for the window pointer.
  - does not manage the resize event.
- `VulkanApplication`:
  - the required extensions for instance creation are received from SDL.
  - subscription to window resize event is made with `eventManagement`.