### PR TITLE
Add normal attribute

### DIFF
--- a/VulkanProject/assets/shaders/shader.frag
+++ b/VulkanProject/assets/shaders/shader.frag
@@ -1,6 +1,6 @@
 #version 450
 
-layout(location = 0) in vec3 fragColor;
+layout(location = 0) in vec3 fragNormal;
 layout(location = 1) in vec2 fragTexCoord;
 
 layout(set = 0, binding = 1) uniform sampler texSampler;

--- a/VulkanProject/assets/shaders/shader.vert
+++ b/VulkanProject/assets/shaders/shader.vert
@@ -7,14 +7,14 @@ layout(binding = 0) uniform UniformBufferObject {
 } ubo;
 
 layout(location = 0) in vec3 inPosition;
-layout(location = 1) in vec3 inColor;
+layout(location = 1) in vec3 inNormal;
 layout(location = 2) in vec2 inTexCoord;
 
-layout(location = 0) out vec3 fragColor;
+layout(location = 0) out vec3 fragNormal;
 layout(location = 1) out vec2 fragTexCoord;
 
 void main() {
     gl_Position = ubo.proj * ubo.view * ubo.model * vec4(inPosition, 1.0);
-    fragColor = inColor;
+    fragNormal = inNormal;
     fragTexCoord = inTexCoord;
 }

--- a/VulkanProject/src/Model.cpp
+++ b/VulkanProject/src/Model.cpp
@@ -18,13 +18,12 @@ void Model::loadModel(Device device, CommandManager commandManager, std::string 
 
 	if (!reader.ParseFromFile(modelPath, reader_config)) {
 		if (!reader.Error().empty()) {
-			std::cerr << "TinyObjReader: " << reader.Error();
+			throw std::runtime_error(reader.Error());
 		}
-		exit(1);
 	}
 
 	if (!reader.Warning().empty()) {
-		std::cout << "TinyObjReader: " << reader.Warning();
+		std::cout << "TinyObjLoader: " << reader.Warning();
 	}
 
 	auto& attrib = reader.GetAttrib();

--- a/VulkanProject/src/Model.cpp
+++ b/VulkanProject/src/Model.cpp
@@ -11,24 +11,35 @@ void Model::loadModel(Device device, CommandManager commandManager, std::string 
 	this->device = device;
 
 	//--------------------------------------------------------
-	// Elements loaded from obj file
-	tinyobj::attrib_t attrib;
-	std::vector<tinyobj::shape_t> shapes;
-	std::vector<tinyobj::material_t> materials; // unused
-	std::string warn, err;
+	// Load obj file
 
-	// Load the model
-	if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, modelPath.c_str())) {
-		throw std::runtime_error(warn + err);
+	tinyobj::ObjReader reader;
+	tinyobj::ObjReaderConfig reader_config;
+
+	if (!reader.ParseFromFile(modelPath, reader_config)) {
+		if (!reader.Error().empty()) {
+			std::cerr << "TinyObjReader: " << reader.Error();
+		}
+		exit(1);
 	}
 
-	//--------------------------------------------------------
-	// POPULLATE THE VERTICES
+	if (!reader.Warning().empty()) {
+		std::cout << "TinyObjReader: " << reader.Warning();
+	}
 
+	auto& attrib = reader.GetAttrib();
+	auto& shapes = reader.GetShapes();
+
+	//--------------------------------------------------------
+	// Fill in the model with the loaded data
+	
 	std::unordered_map<Vertex, uint32_t> uniqueVertices{};
 
+	// SHAPES LOOP
 	for (const auto& shape : shapes) {
+		// FACES LOOP
 		for (const auto& index : shape.mesh.indices) {
+
 			Vertex vertex{};
 
 			//-------------------------
@@ -39,15 +50,25 @@ void Model::loadModel(Device device, CommandManager commandManager, std::string 
 				attrib.vertices[3 * index.vertex_index + 2]
 			};
 
-			// TEXCOORDS
-			//	the vertical component is flipped for correct visualization (OBJ to Vulkan conversion)
-			vertex.texCoord = {
-				attrib.texcoords[2 * index.texcoord_index + 0],
-				1.0f - attrib.texcoords[2 * index.texcoord_index + 1]
-			};
+			//-------------------------
+			// NORMAL
+			if (index.normal_index >= 0) {
+				vertex.normal = {
+					attrib.normals[3 * index.normal_index + 0],
+					attrib.normals[3 * index.normal_index + 1],
+					attrib.normals[3 * index.normal_index + 2]
+				};
+			}
 
-			// BASE COLOR
-			vertex.color = { 1.0f, 1.0f, 1.0f };
+			//-------------------------
+			// TEXTURE COORDINATES
+			if (index.texcoord_index >= 0) {
+				// flip vertical component for correct visualization (OBJ to Vulkan conversion)
+				vertex.texCoord = {
+					attrib.texcoords[2 * index.texcoord_index + 0],
+					1.0f - attrib.texcoords[2 * index.texcoord_index + 1]
+				};
+			}
 
 			//-------------------------
 			// check if the vertex already exists and store the index

--- a/VulkanProject/src/Vertex.hpp
+++ b/VulkanProject/src/Vertex.hpp
@@ -10,7 +10,7 @@
 
 struct Vertex {
 	glm::vec3 pos;
-	glm::vec3 color;
+	glm::vec3 normal;
 	glm::vec2 texCoord;
 
 	static VkVertexInputBindingDescription getBindingDescription() {
@@ -35,7 +35,7 @@ struct Vertex {
 		attributeDescriptions[1].binding = 0;
 		attributeDescriptions[1].location = 1;
 		attributeDescriptions[1].format = VK_FORMAT_R32G32B32_SFLOAT;
-		attributeDescriptions[1].offset = offsetof(Vertex, color);
+		attributeDescriptions[1].offset = offsetof(Vertex, normal);
 
 		// Texture coordinates attribute
 		attributeDescriptions[2].binding = 0;
@@ -47,7 +47,7 @@ struct Vertex {
 	}
 
 	bool operator==(const Vertex& other) const {
-		return pos == other.pos && color == other.color && texCoord == other.texCoord;
+		return pos == other.pos && normal == other.normal && texCoord == other.texCoord;
 	}
 };
 
@@ -55,7 +55,7 @@ namespace std {
 	template<> struct hash<Vertex> {
 		size_t operator()(Vertex const& vertex) const {
 			return ((hash<glm::vec3>()(vertex.pos) ^
-				(hash<glm::vec3>()(vertex.color) << 1)) >> 1) ^
+				(hash<glm::vec3>()(vertex.normal) << 1)) >> 1) ^
 				(hash<glm::vec2>()(vertex.texCoord) << 1);
 		}
 	};


### PR DESCRIPTION
### Description

The color attribute is difficult to be set in OBJ files, so it has been replaced by normal attribute, loading it from the file. Normals are going to be needed in Blinn-Phong lighting and other algorithms.
Also, the loading method has changed, the previous one is marked as deprecated in the repository of [tinyobjloader](https://github.com/tinyobjloader/tinyobjloader) (see its README).
