### PR TITLE
Blinn phong

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     ${SOURCE_CODE_PATH}/eventManagement.cpp
     ${SOURCE_CODE_PATH}/FirstPassPipeline.cpp
     ${SOURCE_CODE_PATH}/imageUtils.cpp
+    ${SOURCE_CODE_PATH}/Light.cpp
     ${SOURCE_CODE_PATH}/Model.cpp
     ${SOURCE_CODE_PATH}/pipelineUtils.cpp
     ${SOURCE_CODE_PATH}/SecondPassPipeline.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 set(SOURCES
     ${TEST_FILES}
     ${SOURCE_CODE_PATH}/AppTime.cpp
+    ${SOURCE_CODE_PATH}/Camera.cpp
     ${SOURCE_CODE_PATH}/CommandManager.cpp
     ${SOURCE_CODE_PATH}/Device.cpp
     ${SOURCE_CODE_PATH}/eventManagement.cpp

--- a/VulkanProject/assets/shaders/shader.frag
+++ b/VulkanProject/assets/shaders/shader.frag
@@ -11,8 +11,7 @@ layout(set = 0, binding = 1) uniform LightUBO {
 } light;
 
 layout(set = 0, binding = 2) uniform sampler texSampler;
-layout(set = 0, binding = 3) uniform texture2D colorTex;
-layout(set = 0, binding = 4) uniform texture2D normalTex;
+layout(set = 0, binding = 3) uniform texture2D textures[2];
 
 layout(location = 0) out vec4 outColor;
 
@@ -21,7 +20,7 @@ float SHININESS = 20.0f;
 
 void main() {
 
-    vec3 color = texture(sampler2D(colorTex, texSampler), fragTexCoord).rgb;
+    vec3 color = texture(sampler2D(textures[0], texSampler), fragTexCoord).rgb;
     vec3 normal = normalize(fragNormal);
     vec3 lightDir = normalize(light.pos - fragPosition);
     vec3 viewDir = normalize(-fragPosition); // cameraPos - pos -> cameraPos = center of the space

--- a/VulkanProject/assets/shaders/shader.frag
+++ b/VulkanProject/assets/shaders/shader.frag
@@ -1,16 +1,46 @@
 #version 450
 
-layout(location = 0) in vec3 fragNormal;
-layout(location = 1) in vec2 fragTexCoord;
+layout(location = 0) in vec3 fragPosition;
+layout(location = 1) in vec3 fragNormal;
+layout(location = 2) in vec2 fragTexCoord;
 
-layout(set = 0, binding = 1) uniform sampler texSampler;
-layout(set = 0, binding = 2) uniform texture2D colorTex;
-layout(set = 0, binding = 3) uniform texture2D normalTex;
+layout(set = 0, binding = 1) uniform LightUBO {
+    vec3 pos;
+    vec3 color;
+    vec3 direction;
+} light;
+
+layout(set = 0, binding = 2) uniform sampler texSampler;
+layout(set = 0, binding = 3) uniform texture2D colorTex;
+layout(set = 0, binding = 4) uniform texture2D normalTex;
 
 layout(location = 0) out vec4 outColor;
 
+vec3 AMBIENT_COLOR = vec3(0.15);
+float SHININESS = 20.0f;
+
 void main() {
-    vec3 colorTexValue = texture(sampler2D(colorTex, texSampler), fragTexCoord).rgb;
-    vec3 normalTexValue = texture(sampler2D(normalTex, texSampler), fragTexCoord).rgb;
-    outColor = vec4(colorTexValue * normalTexValue, 1.0f);
+
+    vec3 color = texture(sampler2D(colorTex, texSampler), fragTexCoord).rgb;
+    vec3 normal = normalize(fragNormal);
+    vec3 lightDir = normalize(light.pos - fragPosition);
+    vec3 viewDir = normalize(-fragPosition); // cameraPos - pos -> cameraPos = center of the space
+    
+    // ambient
+    vec3 ambient = AMBIENT_COLOR * color;
+    
+    // diffuse
+    float diff = max(dot(lightDir, normal), 0.0);
+    vec3 diffuse = diff * light.color;
+
+    // specular
+    vec3 reflectDir = reflect(-lightDir, normal);
+
+    vec3 halfwayDir = normalize(lightDir + viewDir);
+
+    float spec = pow(max(dot(normal, halfwayDir), 0.0), SHININESS);
+    vec3 specular = light.color * spec;
+
+    vec3 result = (color * ambient) + (color * diffuse) + specular;
+    outColor = vec4(result, 1.0);
 }

--- a/VulkanProject/assets/shaders/shader.vert
+++ b/VulkanProject/assets/shaders/shader.vert
@@ -10,11 +10,14 @@ layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;
 layout(location = 2) in vec2 inTexCoord;
 
-layout(location = 0) out vec3 fragNormal;
-layout(location = 1) out vec2 fragTexCoord;
+layout(location = 0) out vec3 fragPosition;
+layout(location = 1) out vec3 fragNormal;
+layout(location = 2) out vec2 fragTexCoord;
 
 void main() {
-    gl_Position = ubo.proj * ubo.view * ubo.model * vec4(inPosition, 1.0);
+    vec4 positionTemp = ubo.view * ubo.model * vec4(inPosition, 1.0);
+    fragPosition = positionTemp.xyz;
     fragNormal = inNormal;
     fragTexCoord = inTexCoord;
+    gl_Position = ubo.proj * positionTemp;
 }

--- a/VulkanProject/assets/shaders/shader.vert
+++ b/VulkanProject/assets/shaders/shader.vert
@@ -1,8 +1,8 @@
 #version 450
 
 layout(binding = 0) uniform UniformBufferObject {
-    mat4 model;
-    mat4 view;
+    mat4 modelView;
+    mat4 invTrans_modelView;
     mat4 proj;
 } ubo;
 
@@ -15,9 +15,9 @@ layout(location = 1) out vec3 fragNormal;
 layout(location = 2) out vec2 fragTexCoord;
 
 void main() {
-    vec4 positionTemp = ubo.view * ubo.model * vec4(inPosition, 1.0);
+    vec4 positionTemp = ubo.modelView * vec4(inPosition, 1.0);
     fragPosition = positionTemp.xyz;
-    fragNormal = inNormal;
+    fragNormal = (ubo.invTrans_modelView * vec4(inNormal, 0.0f)).xyz;
     fragTexCoord = inTexCoord;
     gl_Position = ubo.proj * positionTemp;
 }

--- a/VulkanProject/src/AppTime.cpp
+++ b/VulkanProject/src/AppTime.cpp
@@ -8,16 +8,32 @@ float AppTime::timeValue;
 float AppTime::deltaTimeValue;
 
 timeStamp AppTime::startTimeStamp;
+timeStamp AppTime::lastTimeStamp;
+
+namespace {
+
+	float parseChronoValue(std::chrono::steady_clock::duration& duration) {
+		return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+	}
+
+	float parseChronoValue(timeStamp time) {
+		return parseChronoValue(time.time_since_epoch());
+	}
+}
 
 void AppTime::updateDeltaTime() {
 
 	if (!initialized) {
 		initialized = true;
 		startTimeStamp = std::chrono::high_resolution_clock::now();
-		startTimeValue = startTimeStamp.time_since_epoch().count();
+		startTimeValue = parseChronoValue(startTimeStamp);
+		lastTimeStamp = startTimeStamp;
 	}
 
-	auto currentTime = std::chrono::high_resolution_clock::now();
-	timeValue = currentTime.time_since_epoch().count();
-	deltaTimeValue = std::chrono::duration<float, std::chrono::seconds::period>(currentTime - startTimeStamp).count();
+	auto currentTimeStamp = std::chrono::high_resolution_clock::now();
+
+	timeValue = parseChronoValue(currentTimeStamp - startTimeStamp);
+	deltaTimeValue = parseChronoValue(currentTimeStamp - lastTimeStamp);
+
+	lastTimeStamp = currentTimeStamp;
 }

--- a/VulkanProject/src/AppTime.hpp
+++ b/VulkanProject/src/AppTime.hpp
@@ -9,8 +9,8 @@ class AppTime {
 public:
 
 	static float time() { return timeValue; }
-	static float deltaTime() { return deltaTimeValue; }
-	static float startTime() { return startTimeValue; }
+	static float deltaTime() { return parseToSeconds(deltaTimeValue); }
+	static float startTime() { return parseToSeconds(startTimeValue); }
 
 	static void updateDeltaTime();
 
@@ -22,4 +22,9 @@ private:
 	static float deltaTimeValue;
 
 	static timeStamp startTimeStamp;
+	static timeStamp lastTimeStamp;
+
+	inline static float parseToSeconds(float time) {
+		return time / 1000000000.0f;
+	}
 };

--- a/VulkanProject/src/Camera.cpp
+++ b/VulkanProject/src/Camera.cpp
@@ -1,0 +1,43 @@
+#include "Camera.hpp"
+
+#define GLM_FORCE_RADIANS
+#define GLM_FORCE_DEPTH_ZERO_TO_ONE
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+
+Camera::Camera() {
+	transform.position = glm::vec3(0.0f, 3.0, 0.5f);
+	transform.lookAt = glm::vec3(0.0f, -1.0f, 0.0f);
+	transform.up = glm::vec3(0.0f, 0.0f, 1.0f);
+
+	view = glm::mat4();
+	projection = glm::mat4();
+}
+
+void Camera::init(SwapChain swapChain) {
+	this->swapChain = swapChain;
+	updateMatrices();
+}
+
+void Camera::update() {
+
+	updateMatrices();
+}
+
+void Camera::updateMatrices() {
+	computeView();
+	computeProjection();
+}
+
+void Camera::computeView() {
+	view = glm::lookAt(
+		transform.position, glm::vec3(0.0f), transform.up);
+}
+
+void Camera::computeProjection() {
+	float aspectRatio = swapChain.getExtent().width / (float)swapChain.getExtent().height;
+	projection = glm::perspective(
+		glm::radians(45.0f), aspectRatio, 0.1f, 10.0f);
+	projection[1][1] *= -1; // non-OpenGL GLM usage adjustment
+}

--- a/VulkanProject/src/Camera.cpp
+++ b/VulkanProject/src/Camera.cpp
@@ -32,7 +32,7 @@ void Camera::updateMatrices() {
 
 void Camera::computeView() {
 	view = glm::lookAt(
-		transform.position, glm::vec3(0.0f), transform.up);
+		transform.position, transform.position + transform.lookAt, transform.up);
 }
 
 void Camera::computeProjection() {

--- a/VulkanProject/src/Camera.hpp
+++ b/VulkanProject/src/Camera.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include "Transform.hpp"
+#include "SwapChain.hpp"
+
+
+class Camera{
+public:
+	glm::mat4 getView() { return view; }
+	glm::mat4 getProjection() { return projection; }
+
+	Camera();
+
+	void init(SwapChain swapChain);
+
+	void update();
+
+private:
+	SwapChain swapChain;
+
+	Transform transform;
+	glm::mat4 view;
+	glm::mat4 projection;
+
+	void computeView();
+	void computeProjection();
+	void updateMatrices();
+
+};

--- a/VulkanProject/src/FirstPassPipeline.cpp
+++ b/VulkanProject/src/FirstPassPipeline.cpp
@@ -147,9 +147,17 @@ void FirstPassPipeline::createDescriptorSetLayout(TextureManager textures) {
 	uboLayoutBinding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 
 	//---------------------
+	// ligth ubo binding
+	VkDescriptorSetLayoutBinding lightUboLayoutBinding{};
+	lightUboLayoutBinding.binding = 1;
+	lightUboLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+	lightUboLayoutBinding.descriptorCount = 1;
+	lightUboLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+	//---------------------
 	// sampler binding
 	VkDescriptorSetLayoutBinding samplerLayoutBinding{};
-	samplerLayoutBinding.binding = 1;
+	samplerLayoutBinding.binding = 2;
 	samplerLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
 	samplerLayoutBinding.descriptorCount = 1;
 	samplerLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -159,7 +167,7 @@ void FirstPassPipeline::createDescriptorSetLayout(TextureManager textures) {
 	// Texture bindings
 
 	std::vector<VkDescriptorSetLayoutBinding> textureBindings{};
-	uint32_t currentTextureBinding = 2;
+	uint32_t currentTextureBinding = 3;
 
 	if (textures.getTextureTypesUsed() & TEXTURE_TYPE_ALBEDO_BIT) {
 		textureBindings.push_back(getTextureDescriptorLayoutBinding(currentTextureBinding++));
@@ -178,7 +186,9 @@ void FirstPassPipeline::createDescriptorSetLayout(TextureManager textures) {
 
 	//----------------------------------------------------
 	// CREATE DESCRIPTOR SET
-	std::vector<VkDescriptorSetLayoutBinding> bindings = { uboLayoutBinding, samplerLayoutBinding };
+	std::vector<VkDescriptorSetLayoutBinding> bindings = {
+		uboLayoutBinding, lightUboLayoutBinding, samplerLayoutBinding
+	};
 	bindings.insert(bindings.end(), textureBindings.begin(), textureBindings.end());
 
 	VkDescriptorSetLayoutCreateInfo layoutInfo{};

--- a/VulkanProject/src/FirstPassPipeline.cpp
+++ b/VulkanProject/src/FirstPassPipeline.cpp
@@ -11,18 +11,6 @@
 #include "Vertex.hpp"
 
 
-namespace {
-	VkDescriptorSetLayoutBinding getTextureDescriptorLayoutBinding(uint32_t binding) {
-		VkDescriptorSetLayoutBinding textureLayoutBinding{};
-		textureLayoutBinding.binding = binding;
-		textureLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-		textureLayoutBinding.descriptorCount = 1;
-		textureLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-
-		return textureLayoutBinding;
-	}
-}
-
 void FirstPassPipeline::create(Device device, VkFormat imageFormat, VkFormat depthFormat, TextureManager textures,
 	std::string vertShaderLocation, std::string fragShaderLocation) {
 
@@ -138,10 +126,12 @@ void FirstPassPipeline::createDescriptorSetLayout(TextureManager textures) {
 	//----------------------------------------------------
 	// BINDINGS
 
+	uint32_t binding = 0;
+
 	//---------------------
 	// ubo binding
 	VkDescriptorSetLayoutBinding uboLayoutBinding{};
-	uboLayoutBinding.binding = 0;
+	uboLayoutBinding.binding = binding++;
 	uboLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 	uboLayoutBinding.descriptorCount = 1;
 	uboLayoutBinding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
@@ -149,7 +139,7 @@ void FirstPassPipeline::createDescriptorSetLayout(TextureManager textures) {
 	//---------------------
 	// ligth ubo binding
 	VkDescriptorSetLayoutBinding lightUboLayoutBinding{};
-	lightUboLayoutBinding.binding = 1;
+	lightUboLayoutBinding.binding = binding++;
 	lightUboLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 	lightUboLayoutBinding.descriptorCount = 1;
 	lightUboLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -157,39 +147,25 @@ void FirstPassPipeline::createDescriptorSetLayout(TextureManager textures) {
 	//---------------------
 	// sampler binding
 	VkDescriptorSetLayoutBinding samplerLayoutBinding{};
-	samplerLayoutBinding.binding = 2;
+	samplerLayoutBinding.binding = binding++;
 	samplerLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
 	samplerLayoutBinding.descriptorCount = 1;
 	samplerLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 	samplerLayoutBinding.pImmutableSamplers = nullptr; // Optional
 
 	//---------------------
-	// Texture bindings
-
-	std::vector<VkDescriptorSetLayoutBinding> textureBindings{};
-	uint32_t currentTextureBinding = 3;
-
-	if (textures.getTextureTypesUsed() & TEXTURE_TYPE_ALBEDO_BIT) {
-		textureBindings.push_back(getTextureDescriptorLayoutBinding(currentTextureBinding++));
-	}
-	if (textures.getTextureTypesUsed() & TEXTURE_TYPE_SPECULAR_BIT) {
-		textureBindings.push_back(getTextureDescriptorLayoutBinding(currentTextureBinding++));
-	}
-	if (textures.getTextureTypesUsed() & TEXTURE_TYPE_NORMAL_BIT) {
-		textureBindings.push_back(getTextureDescriptorLayoutBinding(currentTextureBinding++));
-	}
-	if (textures.getTextureTypesUsed() & TEXTURE_TYPE_CUSTOM_BIT) {
-		for (size_t i = 0; i < textures.getCustomTextures().size(); i++) {
-			textureBindings.push_back(getTextureDescriptorLayoutBinding(currentTextureBinding++));
-		}
-	}
+	// textures binding
+	VkDescriptorSetLayoutBinding texturesLayoutBinding{};
+	texturesLayoutBinding.binding = binding;
+	texturesLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+	texturesLayoutBinding.descriptorCount = textures.getTextureCount();
+	texturesLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
 	//----------------------------------------------------
 	// CREATE DESCRIPTOR SET
 	std::vector<VkDescriptorSetLayoutBinding> bindings = {
-		uboLayoutBinding, lightUboLayoutBinding, samplerLayoutBinding
+		uboLayoutBinding, lightUboLayoutBinding, samplerLayoutBinding, texturesLayoutBinding
 	};
-	bindings.insert(bindings.end(), textureBindings.begin(), textureBindings.end());
 
 	VkDescriptorSetLayoutCreateInfo layoutInfo{};
 	layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/VulkanProject/src/Light.cpp
+++ b/VulkanProject/src/Light.cpp
@@ -1,0 +1,13 @@
+#include "Light.hpp"
+
+
+Light::Light() {
+	transform.position = glm::vec3(2.0);
+	transform.lookAt = glm::vec3(0.0f) - transform.position;
+	transform.up = glm::vec3(0.0f); // Not orthogonal space
+	color = glm::vec3(0.5f, 0.437f, 0.365f);
+}
+
+void Light::update() {
+
+}

--- a/VulkanProject/src/Light.hpp
+++ b/VulkanProject/src/Light.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include "Transform.hpp"
+#include "SwapChain.hpp"
+
+
+class Light {
+public:
+
+	glm::vec3 getPosition() { return transform.position; }
+	glm::vec3 getColor() { return color; }
+	glm::vec3 getDirection() { return transform.lookAt; }
+
+	Light();
+
+	void update();
+
+private:
+
+	Transform transform;
+	glm::vec3 color;
+
+};

--- a/VulkanProject/src/Model.cpp
+++ b/VulkanProject/src/Model.cpp
@@ -123,8 +123,10 @@ void Model::createModelBuffer(CommandManager commandManager, VkDeviceSize buffer
 }
 
 void Model::update() {
+	static float angle = 0.0f;
+	angle += AppTime::deltaTime() * glm::radians(90.0f);
 	model = glm::rotate(
-		glm::mat4(1.0f), AppTime::deltaTime() * glm::radians(90.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+		glm::mat4(1.0f), angle * glm::radians(90.0f), glm::vec3(0.0f, 0.0f, 1.0f));
 }
 
 void Model::cleanup() {

--- a/VulkanProject/src/TextureManager.cpp
+++ b/VulkanProject/src/TextureManager.cpp
@@ -36,6 +36,7 @@ void TextureManager::addTexture(TextureType type, ImageObjects texture) {
 
 	// Store the type
 	usedTypes |= type;
+	textureCount++;
 }
 
 void TextureManager::createTexture(TextureType type, std::string texturePath) {
@@ -48,18 +49,23 @@ void TextureManager::createTexture(TextureType type, std::string texturePath) {
 	addTexture(type, newTexture);
 }
 
+void TextureManager::destroyTexture(ImageObjects texture) {
+	destroyImageObjects(device, texture);
+	textureCount--;
+}
+
 void TextureManager::destroyTexture(TextureType type) {
 	switch (type) {
 	case TEXTURE_TYPE_ALBEDO_BIT:
-		destroyImageObjects(device, albedo);
+		destroyTexture(albedo);
 		usedTypes -= TEXTURE_TYPE_ALBEDO_BIT;
 		break;
 	case TEXTURE_TYPE_SPECULAR_BIT:
-		destroyImageObjects(device, specular);
+		destroyTexture(specular);
 		usedTypes -= TEXTURE_TYPE_SPECULAR_BIT;
 		break;
 	case TEXTURE_TYPE_NORMAL_BIT:
-		destroyImageObjects(device, normal);
+		destroyTexture(normal);
 		usedTypes -= TEXTURE_TYPE_NORMAL_BIT;
 		break;
 	case TEXTURE_TYPE_CUSTOM_BIT:
@@ -72,7 +78,7 @@ void TextureManager::destroyTexture(TextureType type) {
 
 void TextureManager::destroyCustomTexture(size_t index) {
 	ImageObjects oldTexture = customTextures[index];
-	destroyImageObjects(device, oldTexture);
+	destroyTexture(customTextures[index]);
 	customTextures.erase(customTextures.begin() + index);
 
 	if (customTextures.size() == 0) usedTypes -= TEXTURE_TYPE_CUSTOM_BIT;

--- a/VulkanProject/src/TextureManager.hpp
+++ b/VulkanProject/src/TextureManager.hpp
@@ -31,6 +31,8 @@ public:
 	ImageObjects getCustomTexture(size_t index) { return customTextures[index]; }
 	std::vector<ImageObjects> getCustomTextures() { return customTextures; }
 
+	uint32_t getTextureCount() { return textureCount; }
+
 	VkSampler getSampler() { return sampler; }
 
 
@@ -63,6 +65,7 @@ private:
 	Device device;
 	CommandManager commandManager;
 
+	uint32_t textureCount = 0;
 	int usedTypes = 0;
 	ImageObjects albedo;
 	ImageObjects specular;
@@ -79,6 +82,9 @@ private:
 	
 	// Create sampler for the textures
 	void createSampler(uint32_t mipLevels);
+
+	// Destroy the texture
+	void destroyTexture(ImageObjects texture);
 };
 
 

--- a/VulkanProject/src/Transform.hpp
+++ b/VulkanProject/src/Transform.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+
+struct Transform {
+	glm::vec3 position;
+	glm::vec3 lookAt;
+	glm::vec3 up;
+};

--- a/VulkanProject/src/UniformManager.cpp
+++ b/VulkanProject/src/UniformManager.cpp
@@ -49,11 +49,13 @@ void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera,
 	UniformBufferObject ubo{};
 
 	//-------------------------
-	// MODEL
-	ubo.model = model;
+	// CAMERA VIEW
+	glm::mat4 view = camera.getView();
+
 	//-------------------------
-	// CAMERA VARIABLES
-	ubo.view = camera.getView();
+	// COMPUTE MATRICES
+	ubo.modelView = view * model;
+	ubo.invTrans_modelView = glm::inverse(glm::transpose(ubo.modelView));
 	ubo.proj = camera.getProjection();
 
 	//-------------------------
@@ -61,8 +63,8 @@ void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera,
 	LightUBO fragUBO{};
 
 	// Light pos and dir in camera coordinates
-	glm::vec4 lightPos = ubo.view * glm::vec4(light.getPosition(), 0.0f);
-	glm::vec4 lightDirection = ubo.view * glm::vec4(light.getDirection(), 0.0f);
+	glm::vec4 lightPos = view * glm::vec4(light.getPosition(), 1.0f);
+	glm::vec4 lightDirection = view * glm::vec4(light.getDirection(), 0.0f);
 	fragUBO.lightPos = glm::vec3(lightPos);
 	fragUBO.lightColor = light.getColor();
 	fragUBO.lightDirection = glm::vec3(lightDirection);

--- a/VulkanProject/src/UniformManager.cpp
+++ b/VulkanProject/src/UniformManager.cpp
@@ -42,7 +42,7 @@ void UniformManager::createBuffers(Device device, int count) {
 	vkMapMemory(device.get(), lightUBOMemory, 0, bufferSize, 0, &lightUBOMapped);
 }
 
-void UniformManager::upateBuffer(uint32_t index, uint32_t screenWidth, uint32_t screenHeight, glm::mat4 model) {
+void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera) {
 	//--------------------------------------------------------
 	// UNIFORM VALUES
 
@@ -52,15 +52,9 @@ void UniformManager::upateBuffer(uint32_t index, uint32_t screenWidth, uint32_t 
 	// MODEL
 	ubo.model = model;
 	//-------------------------
-	// VIEW
-	glm::vec3 cameraPos = glm::vec3(3.0f, 0.0f, 2.0f);
-	ubo.view = glm::lookAt(
-		cameraPos, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
-	//-------------------------
-	// PROJECTION
-	ubo.proj = glm::perspective(
-		glm::radians(45.0f), screenWidth / (float)screenHeight, 0.1f, 10.0f);
-	ubo.proj[1][1] *= -1; // non-OpenGL GLM usage adjustment
+	// CAMERA VARIABLES
+	ubo.view = camera.getView();
+	ubo.proj = camera.getProjection();
 
 	//-------------------------
 	// LIGHT VARIABLES

--- a/VulkanProject/src/UniformManager.cpp
+++ b/VulkanProject/src/UniformManager.cpp
@@ -60,20 +60,20 @@ void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera,
 
 	//-------------------------
 	// LIGHT VARIABLES
-	LightUBO fragUBO{};
+	LightUBO lightUBO{};
 
 	// Light pos and dir in camera coordinates
 	glm::vec4 lightPos = view * glm::vec4(light.getPosition(), 1.0f);
 	glm::vec4 lightDirection = view * glm::vec4(light.getDirection(), 0.0f);
-	fragUBO.lightPos = glm::vec3(lightPos);
-	fragUBO.lightColor = light.getColor();
-	fragUBO.lightDirection = glm::vec3(lightDirection);
+	lightUBO.pos = glm::vec3(lightPos);
+	lightUBO.color = light.getColor();
+	lightUBO.direction = glm::vec3(lightDirection);
 
 	//--------------------------------------------------------
 	// UPDATE BUFFER
 
 	memcpy(buffersMapped[index], &ubo, sizeof(ubo));
-	memcpy(lightUBOMapped, &fragUBO, sizeof(LightUBO));
+	memcpy(lightUBOMapped, &lightUBO, sizeof(LightUBO));
 }
 
 void UniformManager::cleanup() {

--- a/VulkanProject/src/UniformManager.cpp
+++ b/VulkanProject/src/UniformManager.cpp
@@ -42,7 +42,7 @@ void UniformManager::createBuffers(Device device, int count) {
 	vkMapMemory(device.get(), lightUBOMemory, 0, bufferSize, 0, &lightUBOMapped);
 }
 
-void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera) {
+void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera, Light light) {
 	//--------------------------------------------------------
 	// UNIFORM VALUES
 
@@ -61,10 +61,10 @@ void UniformManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera)
 	LightUBO fragUBO{};
 
 	// Light pos and dir in camera coordinates
-	glm::vec4 lightPos = ubo.view * glm::vec4(0.0f, 2.0f, 3.0f, 1.0f);
-	glm::vec4 lightDirection = ubo.view * glm::vec4(1.0f, -1.0f, 0.0f, 0.0f);
+	glm::vec4 lightPos = ubo.view * glm::vec4(light.getPosition(), 0.0f);
+	glm::vec4 lightDirection = ubo.view * glm::vec4(light.getDirection(), 0.0f);
 	fragUBO.lightPos = glm::vec3(lightPos);
-	fragUBO.lightColor = glm::vec3(0.5f, 0.437f, 0.365f);
+	fragUBO.lightColor = light.getColor();
 	fragUBO.lightDirection = glm::vec3(lightDirection);
 
 	//--------------------------------------------------------

--- a/VulkanProject/src/UniformManager.hpp
+++ b/VulkanProject/src/UniformManager.hpp
@@ -8,10 +8,19 @@
 
 // See alignment requirements in specification
 // (https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-layout)
+// TODO: improve organization: create Camera class
+// TODO: improve organization: give modelView and proj matrices (avoiding unnecessary operations in shader)
 struct UniformBufferObject {
     alignas(16) glm::mat4 model;
     alignas(16) glm::mat4 view;
     alignas(16) glm::mat4 proj;
+};
+
+// TODO: improve organization: create Light class
+struct LightUBO {
+    alignas(16) glm::vec3 lightPos;
+    alignas(16) glm::vec3 lightColor;
+    alignas(16) glm::vec3 lightDirection;
 };
 
 
@@ -22,6 +31,7 @@ public:
     // GETTERS AND SETTERS
 
     VkBuffer getBuffer(size_t index) { return buffers[index]; }
+    VkBuffer getLightBuffer() { return lightUBOBuffer; }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // METHODS
@@ -45,4 +55,9 @@ private:
     std::vector<VkBuffer> buffers;
     std::vector<VkDeviceMemory> buffersMemory;
     std::vector<void*> buffersMapped;
+
+    VkBuffer lightUBOBuffer;
+    VkDeviceMemory lightUBOMemory;
+    void* lightUBOMapped;
+
 };

--- a/VulkanProject/src/UniformManager.hpp
+++ b/VulkanProject/src/UniformManager.hpp
@@ -16,11 +16,10 @@ struct UniformBufferObject {
     alignas(16) glm::mat4 proj;
 };
 
-// TODO: improve organization: create Light class
 struct LightUBO {
-    alignas(16) glm::vec3 lightPos;
-    alignas(16) glm::vec3 lightColor;
-    alignas(16) glm::vec3 lightDirection;
+    alignas(16) glm::vec3 pos;
+    alignas(16) glm::vec3 color;
+    alignas(16) glm::vec3 direction;
 };
 
 

--- a/VulkanProject/src/UniformManager.hpp
+++ b/VulkanProject/src/UniformManager.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "Device.hpp"
+#include "Camera.hpp"
 
 
 // See alignment requirements in specification
@@ -40,7 +41,7 @@ public:
     void createBuffers(Device device, int count);
 
     // Update uniform values
-    void upateBuffer(uint32_t currentImage, uint32_t screenWidth, uint32_t screenHeight, glm::mat4 model);
+    void upateBuffer(uint32_t currentImage, glm::mat4 model, Camera camera);
 
     // Destroy Vulkan an other objects
     void cleanup();

--- a/VulkanProject/src/UniformManager.hpp
+++ b/VulkanProject/src/UniformManager.hpp
@@ -10,11 +10,9 @@
 
 // See alignment requirements in specification
 // (https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-layout)
-// TODO: improve organization: create Camera class
-// TODO: improve organization: give modelView and proj matrices (avoiding unnecessary operations in shader)
 struct UniformBufferObject {
-    alignas(16) glm::mat4 model;
-    alignas(16) glm::mat4 view;
+    alignas(16) glm::mat4 modelView;
+    alignas(16) glm::mat4 invTrans_modelView;
     alignas(16) glm::mat4 proj;
 };
 

--- a/VulkanProject/src/UniformManager.hpp
+++ b/VulkanProject/src/UniformManager.hpp
@@ -5,6 +5,7 @@
 
 #include "Device.hpp"
 #include "Camera.hpp"
+#include "Light.hpp"
 
 
 // See alignment requirements in specification
@@ -41,7 +42,7 @@ public:
     void createBuffers(Device device, int count);
 
     // Update uniform values
-    void upateBuffer(uint32_t currentImage, glm::mat4 model, Camera camera);
+    void upateBuffer(uint32_t currentImage, glm::mat4 model, Camera camera, Light light);
 
     // Destroy Vulkan an other objects
     void cleanup();

--- a/VulkanProject/src/VulkanApplication.hpp
+++ b/VulkanProject/src/VulkanApplication.hpp
@@ -29,6 +29,7 @@
 #include "AppTime.hpp"
 #include "eventManagement.hpp"
 #include "Camera.hpp"
+#include "Light.hpp"
 
 
 const uint32_t WIDTH = 800;
@@ -148,8 +149,9 @@ private:
 	// Commands
 	CommandManager commandManager;
 
-	// Camera
+	// Camera and lights
 	Camera camera;
+	Light spotlight;
 
 	// Texture
 	TextureManager textureManager;
@@ -972,12 +974,11 @@ private:
 			throw std::runtime_error("failed to acquire swap chain image");
 		}
 
-		// TODO: change this way and use push constants
 		// UPDATE
 		AppTime::updateDeltaTime();
 		model.update();
 		camera.update();
-		uniformManager.upateBuffer(0, model.getModelMatrix(), camera);
+		uniformManager.upateBuffer(0, model.getModelMatrix(), camera, spotlight);
 
 		vkResetFences(device.get(), 1, &inFlightFences[currentFrame]);
 

--- a/VulkanProject/src/VulkanApplication.hpp
+++ b/VulkanProject/src/VulkanApplication.hpp
@@ -28,6 +28,7 @@
 #include "TextureManager.hpp"
 #include "AppTime.hpp"
 #include "eventManagement.hpp"
+#include "Camera.hpp"
 
 
 const uint32_t WIDTH = 800;
@@ -147,6 +148,9 @@ private:
 	// Commands
 	CommandManager commandManager;
 
+	// Camera
+	Camera camera;
+
 	// Texture
 	TextureManager textureManager;
 
@@ -230,6 +234,8 @@ private:
 		createDepthResources();
 		createFirstPassOutputResources();
 		
+		camera.init(swapChain);
+
 		createTextures(params);
 
 		model.loadModel(device, commandManager, params.modelPath);
@@ -970,7 +976,8 @@ private:
 		// UPDATE
 		AppTime::updateDeltaTime();
 		model.update();
-		uniformManager.upateBuffer(0, swapChain.getExtent().width, swapChain.getExtent().height, model.getModelMatrix());
+		camera.update();
+		uniformManager.upateBuffer(0, model.getModelMatrix(), camera);
 
 		vkResetFences(device.get(), 1, &inFlightFences[currentFrame]);
 

--- a/VulkanProject/src/VulkanApplication.hpp
+++ b/VulkanProject/src/VulkanApplication.hpp
@@ -789,18 +789,20 @@ private:
 		samplerInfo.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 		samplerInfo.sampler = textureManager.getSampler();
 
-		// COLOR TEXTURE INFO
-		VkDescriptorImageInfo colorTextureInfo{};
-		colorTextureInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		colorTextureInfo.imageView = textureManager.getAlbedo().view;
+		// TEXTURES
+		std::vector<VkDescriptorImageInfo> textureInfos(
+			textureManager.getTextureCount(), VkDescriptorImageInfo{});
 
-		// NORMAL TEXTURE INFO
-		VkDescriptorImageInfo normalTextureInfo{};
-		normalTextureInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		normalTextureInfo.imageView = textureManager.getNormal().view;
+		// color
+		textureInfos[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		textureInfos[0].imageView = textureManager.getAlbedo().view;
+
+		// normal
+		textureInfos[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		textureInfos[1].imageView = textureManager.getNormal().view;
 
 		// DESCRIPTOR WRITES
-		std::array<VkWriteDescriptorSet, 5> descriptorWrites{};
+		std::array<VkWriteDescriptorSet, 4> descriptorWrites{};
 
 		// buffer
 		descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -831,23 +833,14 @@ private:
 		descriptorWrites[2].descriptorCount = 1;
 		descriptorWrites[2].pImageInfo = &samplerInfo;
 
-		// color texture
+		// textures
 		descriptorWrites[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 		descriptorWrites[3].dstSet = firstPassDescriptorSet;
 		descriptorWrites[3].dstBinding = 3;
 		descriptorWrites[3].dstArrayElement = 0;
 		descriptorWrites[3].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-		descriptorWrites[3].descriptorCount = 1;
-		descriptorWrites[3].pImageInfo = &colorTextureInfo;
-
-		// normal texture
-		descriptorWrites[4].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-		descriptorWrites[4].dstSet = firstPassDescriptorSet;
-		descriptorWrites[4].dstBinding = 4;
-		descriptorWrites[4].dstArrayElement = 0;
-		descriptorWrites[4].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-		descriptorWrites[4].descriptorCount = 1;
-		descriptorWrites[4].pImageInfo = &normalTextureInfo;
+		descriptorWrites[3].descriptorCount = 2;
+		descriptorWrites[3].pImageInfo = textureInfos.data();
 
 		// UPDATE
 		vkUpdateDescriptorSets(device.get(), static_cast<uint32_t>(descriptorWrites.size()),


### PR DESCRIPTION
### Description

Add basic version of Blinn-Phong algorithm. Add `Light` class to handle light data. Update texture descriptor layouts and allocations to an array of images descriptor. An error with time management in `AppTime` was fixed during the process. Important note: the vertex position and its normal and the light data is passed to the shader in camera coordinates, making easier the computation. Fix vertex normal propagation and made in the camera space.

### Main changes
- Manage textures for the first pass with one descriptor for an array of images, this needed changes in `VulkanApplication`, `TextureManager` and `FirstPassPipeline`
- `Transform` struct with three members: `position`, `lookAt` and `up`, all of them as `glm::vec3`.
- `Light` class. It has a `Transform` and a `glm::vec3 color`.
- Add `LightUBO` struct to `UniformManager`. With three `glm::vec3` members: `lightPos`, `lightDir` and `lightColor`.
- Add a binding in the fragment shader for the light uniform buffer object in `FirstPassPipeline`.
- Implement Blinn-Phong in the first pipeline fragment shader (`shader.frag`).
- Fix normal propagation using $inverse(transpose(view * model))$ as matrix for computing the normal in camera coordinates.
- Update `UniformBufferObject` to have:
  - `viewModel`: avoid three matrix multiplication in vertex shader.
  - `invTrans_viewModel`: to fix normal propagation.
  - `proj`: it cannot be simplified because vertex position has to be in two coordinates: camera for fragment shader and screen (`gl_position`).
- Fix `AppTime` error.

### Possible improvements

- Add `shininess` and `ambient` as uniforms.