### PR TITLE
Model refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ set(SOURCES
     "${SOURCE_CODE_PATH}/render/target/FramebufferResources.cpp"
     "${SOURCE_CODE_PATH}/render/target/SwapChain.cpp"
     "${SOURCE_CODE_PATH}/render/uniform/LightUboManager.cpp"
+    "${SOURCE_CODE_PATH}/render/uniform/Material.cpp"
     "${SOURCE_CODE_PATH}/render/uniform/ModelUboManager.cpp"
-    "${SOURCE_CODE_PATH}/render/uniform/TextureManager.cpp"
 
     "${SOURCE_CODE_PATH}/scene/Camera.cpp"
     "${SOURCE_CODE_PATH}/scene/Light.cpp"

--- a/VulkanProject/src/context/VulkanApplication.hpp
+++ b/VulkanProject/src/context/VulkanApplication.hpp
@@ -27,7 +27,7 @@
 #include "render/pipeline/SecondPassPipeline.hpp"
 #include "render/uniform/LightUboManager.hpp"
 #include "render/uniform/ModelUboManager.hpp"
-#include "render/uniform/TextureManager.hpp"
+#include "render/uniform/Material.hpp"
 #include "scene/Model.hpp"
 #include "scene/Camera.hpp"
 #include "scene/Light.hpp"
@@ -455,15 +455,15 @@ private:
 		camera.init(swapChain.getExtent());
 
 		// MODEL
-		TextureManager modelTextures;
-		modelTextures.create(device, commandManager);
-		modelTextures.createTextures(params.texturePaths[0]);
-		model.create(device, commandManager, params.modelPath, modelTextures);
+		Material modelMaterial;
+		modelMaterial.setContext(device, commandManager);
+		modelMaterial.createTextures(params.texturePaths[0]);
+		model.create(device, commandManager, params.modelPath, modelMaterial);
 
 		// POST-PROCESSING QUAD (the texture is set later)
-		TextureManager postProcTextures;
-		postProcTextures.create(device, commandManager);
-		postProcessingQuad.create(device, commandManager, POST_PROCESSING_QUAD_PATH, postProcTextures, true);
+		Material postProcMaterial;
+		postProcMaterial.setContext(device, commandManager);
+		postProcessingQuad.create(device, commandManager, POST_PROCESSING_QUAD_PATH, postProcMaterial, true);
 
 		lights[0].setColor(glm::vec3(1.0f, 0.0f, 0.0f));
 
@@ -485,7 +485,7 @@ private:
 
 		// POST PROCESSING QUAD TEXTURES
 		ImageObjects firstPassOutputImage = firstPassFramebuffer.getResolveImage();
-		postProcessingQuad.getTextures().addTexture(TEXTURE_TYPE_CUSTOM_BIT, firstPassOutputImage);
+		postProcessingQuad.getMaterial().addTexture(TEXTURE_TYPE_CUSTOM_BIT, firstPassOutputImage);
 	}
 
 	void createSecondPassFramebuffers() {
@@ -565,7 +565,7 @@ private:
 
 	void createFirstPassDescriptorSets() {
 		firstPassPipeline.allocateDescriptorSets(descriptorPool, 1, &firstPassDescriptorSet);
-		firstPassPipeline.updateDescriptorSet(modelUniforms, lightUniforms, model.getTextures(), firstPassDescriptorSet);
+		firstPassPipeline.updateDescriptorSet(modelUniforms, lightUniforms, model.getMaterial(), firstPassDescriptorSet);
 	}
 
 	void createSecondPassDescriptorSets() {
@@ -577,7 +577,7 @@ private:
 	void configureSecondPassDescriptorSets(){
 		// DESCRIPTOR SETS CONFIGURATION
 		for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-			secondPassPipeline.updateDescriptorSet({}, {}, postProcessingQuad.getTextures(), secondPassDescriptorSets[i]);
+			secondPassPipeline.updateDescriptorSet({}, {}, postProcessingQuad.getMaterial(), secondPassDescriptorSets[i]);
 		}
 	}
 
@@ -817,7 +817,7 @@ private:
 
 	void cleanupRenderImages() {
 		// first pass output image
-		postProcessingQuad.getTextures().destroyTextures(false);
+		postProcessingQuad.getMaterial().destroyTextures(false);
 
 		// color attachments
 		firstPassFramebuffer.cleanup();

--- a/VulkanProject/src/context/VulkanApplication.hpp
+++ b/VulkanProject/src/context/VulkanApplication.hpp
@@ -706,7 +706,7 @@ private:
 		}
 
 		// UPDATE UNIFORMS
-		modelUniforms.upateBuffer(0, model.getModelMatrix(), camera);
+		modelUniforms.upateBuffer(0, model, camera);
 		std::vector<Light> lightVec = std::vector<Light>(lights.begin(), lights.end());
 		lightUniforms.upateBuffer(0, lightVec, camera);
 

--- a/VulkanProject/src/context/VulkanApplication.hpp
+++ b/VulkanProject/src/context/VulkanApplication.hpp
@@ -565,7 +565,7 @@ private:
 
 	void createFirstPassDescriptorSets() {
 		firstPassPipeline.allocateDescriptorSets(descriptorPool, 1, &firstPassDescriptorSet);
-		firstPassPipeline.updateDescriptorSet(modelUniforms, lightUniforms, model.getMaterial(), firstPassDescriptorSet);
+		firstPassPipeline.updateDescriptorSet(modelUniforms, model.getMaterial(), lightUniforms, firstPassDescriptorSet);
 	}
 
 	void createSecondPassDescriptorSets() {
@@ -577,7 +577,7 @@ private:
 	void configureSecondPassDescriptorSets(){
 		// DESCRIPTOR SETS CONFIGURATION
 		for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-			secondPassPipeline.updateDescriptorSet({}, {}, postProcessingQuad.getMaterial(), secondPassDescriptorSets[i]);
+			secondPassPipeline.updateDescriptorSet(postProcessingQuad.getMaterial(), secondPassDescriptorSets[i]);
 		}
 	}
 

--- a/VulkanProject/src/context/VulkanApplication.hpp
+++ b/VulkanProject/src/context/VulkanApplication.hpp
@@ -233,16 +233,14 @@ private:
 		lightUniforms.createBuffers(device, 1, lights.size());
 
 		// the pipeline needs the texture count (models already loaded)
-		firstPassPipeline.create(device, swapChain.getImageFormat(), findDepthFormat(device),
-			true, model.getTextures().getTextureCount(), lights.size(),
+		firstPassPipeline.create(device, swapChain.getImageFormat(), findDepthFormat(device), model, lights.size(),
 			params.firstRenderPassVertShaderPath, params.firstRenderPassFragShaderPath);
 
 		// framebuffer needs post-processing texture image view
 		createFirstPassResources();
 
 		// second pipeline needs post-processing texture count
-		secondPassPipeline.create(device, swapChain.getImageFormat(), findDepthFormat(device),
-			false, postProcessingQuad.getTextures().getTextureCount(), 0,
+		secondPassPipeline.create(device, swapChain.getImageFormat(), findDepthFormat(device), postProcessingQuad, 0,
 			params.secondRenderPassVertShaderPath, params.secondRenderPassFragShaderPath);
 		
 		createSecondPassFramebuffers();
@@ -465,7 +463,7 @@ private:
 		// POST-PROCESSING QUAD (the texture is set later)
 		TextureManager postProcTextures;
 		postProcTextures.create(device, commandManager);
-		postProcessingQuad.create(device, commandManager, POST_PROCESSING_QUAD_PATH, postProcTextures);
+		postProcessingQuad.create(device, commandManager, POST_PROCESSING_QUAD_PATH, postProcTextures, true);
 
 		lights[0].setColor(glm::vec3(1.0f, 0.0f, 0.0f));
 

--- a/VulkanProject/src/render/pipeline/GraphicsPipeline.cpp
+++ b/VulkanProject/src/render/pipeline/GraphicsPipeline.cpp
@@ -155,32 +155,29 @@ namespace DescriptorSets {
 	}
 }
 
-// TODO: receive a vector of Model and iterate over them to get their textures
-void GraphicsPipeline::create(Device device, VkFormat imageFormat, VkFormat depthFormat,
-	bool renderModel, uint32_t textureCount, uint32_t lightCount,
+void GraphicsPipeline::create(Device device, VkFormat imageFormat, VkFormat depthFormat, Model model, uint32_t lightCount,
 	std::string vertShaderLocation, std::string fragShaderLocation) {
 
 	this->device = device;
 
 	createRenderPass(imageFormat, depthFormat);
-	createDescriptorSetLayout(
-		renderModel, textureCount, lightCount);
+	createDescriptorSetLayout(model, lightCount);
 	createGraphicsPipeline(vertShaderLocation, fragShaderLocation);
 }
 
 
-void GraphicsPipeline::createDescriptorSetLayout(bool renderModel, uint32_t textureCount,
-	uint32_t lightCount) {
+void GraphicsPipeline::createDescriptorSetLayout(Model model, uint32_t lightCount) {
 
 	//----------------------------------------------------
 	// BINDINGS
 	std::vector<VkDescriptorSetLayoutBinding> bindings;
 
 	// MODEL UBO
-	if (renderModel)
+	if (!model.useRawVertexData())
 		Bindings::addModelBinding(bindings);
 
 	// SAMPLER AND TEXTURE
+	size_t textureCount = model.getTextures().getTextureCount();
 	if (textureCount > 0) {
 		Bindings::addTextureBindings(bindings, textureCount);
 	}

--- a/VulkanProject/src/render/pipeline/GraphicsPipeline.cpp
+++ b/VulkanProject/src/render/pipeline/GraphicsPipeline.cpp
@@ -275,7 +275,12 @@ void GraphicsPipeline::allocateDescriptorSets(VkDescriptorPool pool, uint32_t co
 }
 
 // TODO: move this to a Renderer class
-void GraphicsPipeline::updateDescriptorSet(ModelUboManager modelUniforms, LightUboManager lightsUniforms, Material material,
+void GraphicsPipeline::updateDescriptorSet(Material material, VkDescriptorSet descriptorSet) {
+	updateDescriptorSet({}, material, {}, descriptorSet);
+}
+
+// TODO: move this to a Renderer class
+void GraphicsPipeline::updateDescriptorSet(ModelUboManager modelUniforms, Material material, LightUboManager lightsUniforms,
 	VkDescriptorSet descriptorSet) {
 
 	// DESCRIPTOR WRITES

--- a/VulkanProject/src/render/pipeline/GraphicsPipeline.cpp
+++ b/VulkanProject/src/render/pipeline/GraphicsPipeline.cpp
@@ -66,42 +66,41 @@ namespace DescriptorSets {
 		descriptorWrites.push_back(modelBufferWrite);
 	}
 
-	void addTextureDescriptorWrites(const TextureManager& textures, VkDescriptorSet descriptorSetDst,
+	void addTextureDescriptorWrites(const Material& material, VkDescriptorSet descriptorSetDst,
 		VkDescriptorImageInfo& samplerInfo, std::vector<VkDescriptorImageInfo>& textureInfos,
 		std::vector<VkWriteDescriptorSet>& descriptorWrites) {
 
 		// TEXTURE SAMPLER INFO
 		samplerInfo.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-		samplerInfo.sampler = textures.getSampler();
+		samplerInfo.sampler = material.sampler;
 
 		// TEXTURE INFOS
 
-		textureInfos.resize(textures.getTextureCount());
-		auto usedTypes = textures.getTextureTypesUsed();
+		textureInfos.resize(material.textureCount);
 		int index = 0;
-		if (usedTypes & TEXTURE_TYPE_ALBEDO_BIT) {
+		if (material.hasAlbedo()) {
 			// color
 			textureInfos[index].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-			textureInfos[index].imageView = textures.getAlbedo().view;
+			textureInfos[index].imageView = material.albedoTexture.view;
 			index++;
 		}
-		if (usedTypes & TEXTURE_TYPE_SPECULAR_BIT) {
+		if (material.hasSpecular()) {
 			// specular
 			textureInfos[index].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-			textureInfos[index].imageView = textures.getSpecular().view;
+			textureInfos[index].imageView = material.specularTexture.view;
 			index++;
 		}
-		if (usedTypes & TEXTURE_TYPE_NORMAL_BIT) {
+		if (material.hasNormal()) {
 			// normal
 			textureInfos[index].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-			textureInfos[index].imageView = textures.getNormal().view;
+			textureInfos[index].imageView = material.normalTexture.view;
 			index++;
 		}
-		if (usedTypes & TEXTURE_TYPE_CUSTOM_BIT) {
+		if (material.customTextures.size()) {
 			// custom
-			for (size_t i = 0; i < textures.getTextureCount(); i++) {
+			for (size_t i = 0; i < material.customTextures.size(); i++) {
 				textureInfos[index].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-				textureInfos[index].imageView = textures.getCustomTexture(i).view;
+				textureInfos[index].imageView = material.customTextures[i].view;
 				index++;
 			}
 		}
@@ -177,7 +176,7 @@ void GraphicsPipeline::createDescriptorSetLayout(Model model, uint32_t lightCoun
 		Bindings::addModelBinding(bindings);
 
 	// SAMPLER AND TEXTURE
-	size_t textureCount = model.getTextures().getTextureCount();
+	size_t textureCount = model.getMaterial().textureCount;
 	if (textureCount > 0) {
 		Bindings::addTextureBindings(bindings, textureCount);
 	}
@@ -276,7 +275,7 @@ void GraphicsPipeline::allocateDescriptorSets(VkDescriptorPool pool, uint32_t co
 }
 
 // TODO: move this to a Renderer class
-void GraphicsPipeline::updateDescriptorSet(ModelUboManager modelUniforms, LightUboManager lightsUniforms, TextureManager textures,
+void GraphicsPipeline::updateDescriptorSet(ModelUboManager modelUniforms, LightUboManager lightsUniforms, Material material,
 	VkDescriptorSet descriptorSet) {
 
 	// DESCRIPTOR WRITES
@@ -291,8 +290,8 @@ void GraphicsPipeline::updateDescriptorSet(ModelUboManager modelUniforms, LightU
 	// Sample and textures
 	VkDescriptorImageInfo samplerInfo{};
 	std::vector<VkDescriptorImageInfo> textureInfos;
-	if (textures.getTextureCount() > 0) {
-		DescriptorSets::addTextureDescriptorWrites(textures, descriptorSet, samplerInfo, textureInfos, descriptorWrites);
+	if (material.textureCount > 0) {
+		DescriptorSets::addTextureDescriptorWrites(material, descriptorSet, samplerInfo, textureInfos, descriptorWrites);
 	}
 
 	// Lights UBO

--- a/VulkanProject/src/render/pipeline/GraphicsPipeline.hpp
+++ b/VulkanProject/src/render/pipeline/GraphicsPipeline.hpp
@@ -28,8 +28,11 @@ public:
 	void allocateDescriptorSets(VkDescriptorPool pool, uint32_t count, VkDescriptorSet* descriptorSets);
 
 	// Write a descriptor set with the corresponding data
-	void updateDescriptorSet(ModelUboManager modelUniforms, LightUboManager lightsUniforms, Material material,
+	void updateDescriptorSet(ModelUboManager modelUniforms, Material material, LightUboManager lightsUniforms,
 		VkDescriptorSet descriptorSet);
+
+	// Write a descriptor set with the corresponding data
+	void updateDescriptorSet(Material material, VkDescriptorSet descriptorSet);
 
 	// Record a command buffer with the necessary operations to use the pipeline
 	void recordDrawing(VkCommandBuffer commandBuffer, VkFramebuffer framebuffer, VkExtent2D extent,

--- a/VulkanProject/src/render/pipeline/GraphicsPipeline.hpp
+++ b/VulkanProject/src/render/pipeline/GraphicsPipeline.hpp
@@ -21,8 +21,7 @@ public:
 	// METHODS
 	
 	// Create the graphics pipeline with the specified formats
-	void create(Device device, VkFormat imageFormat, VkFormat depthFormat,
-		bool renderModel, uint32_t textureCount, uint32_t lightCount,
+	void create(Device device, VkFormat imageFormat, VkFormat depthFormat, Model model, uint32_t lightCount,
 		std::string vertShaderLocation, std::string fragShaderLocation);
 
 	// Allocate descriptor sets with the layout of the pipeline
@@ -58,7 +57,7 @@ protected:
 	virtual void createRenderPass(VkFormat imageFormat, VkFormat depthFormat) = 0;
 
 	// Defines the Descriptor Set Layout of the pipeline
-	void createDescriptorSetLayout(bool renderModel, uint32_t textureCount, uint32_t lightCount);
+	void createDescriptorSetLayout(Model model, uint32_t lightCount);
 
 	// Create a GraphicsPipeline with all the stages and a PipelineLayout
 	virtual void createGraphicsPipeline(std::string vertexShaderLocation, std::string fragmentShaderLocation) = 0;

--- a/VulkanProject/src/render/pipeline/GraphicsPipeline.hpp
+++ b/VulkanProject/src/render/pipeline/GraphicsPipeline.hpp
@@ -3,7 +3,7 @@
 #include <vulkan/vulkan.h>
 
 #include "scene/Model.hpp"
-#include "render/uniform/TextureManager.hpp"
+#include "render/uniform/Material.hpp"
 #include "render/uniform/ModelUboManager.hpp"
 #include "render/uniform/LightUboManager.hpp"
 
@@ -28,7 +28,7 @@ public:
 	void allocateDescriptorSets(VkDescriptorPool pool, uint32_t count, VkDescriptorSet* descriptorSets);
 
 	// Write a descriptor set with the corresponding data
-	void updateDescriptorSet(ModelUboManager modelUniforms, LightUboManager lightsUniforms, TextureManager textures,
+	void updateDescriptorSet(ModelUboManager modelUniforms, LightUboManager lightsUniforms, Material material,
 		VkDescriptorSet descriptorSet);
 
 	// Record a command buffer with the necessary operations to use the pipeline

--- a/VulkanProject/src/render/uniform/ModelUboManager.cpp
+++ b/VulkanProject/src/render/uniform/ModelUboManager.cpp
@@ -25,13 +25,13 @@ void ModelUboManager::createBuffers(Device device, int count) {
 	}
 }
 
-void ModelUboManager::upateBuffer(uint32_t index, glm::mat4 model, Camera camera) {
+void ModelUboManager::upateBuffer(uint32_t index, Model model, Camera camera) {
 	
 	ModelUBO ubo{};
 	glm::mat4 view = camera.getView();
 
 	// Compute matrices
-	ubo.modelView = view * model;
+	ubo.modelView = view * createModelMatrix(model.getTransform());
 	ubo.invTrans_modelView = glm::inverse(glm::transpose(ubo.modelView));
 	ubo.proj = camera.getProjection();
 

--- a/VulkanProject/src/render/uniform/ModelUboManager.hpp
+++ b/VulkanProject/src/render/uniform/ModelUboManager.hpp
@@ -5,6 +5,7 @@
 
 #include "context/Device.hpp"
 #include "scene/Camera.hpp"
+#include "scene/Model.hpp"
 
 
 // See alignment requirements in specification
@@ -32,7 +33,7 @@ public:
     void createBuffers(Device device, int count);
 
     // Update uniform values
-    void upateBuffer(uint32_t index, glm::mat4 model, Camera camera);
+    void upateBuffer(uint32_t index, Model model, Camera camera);
 
     // Destroy Vulkan an other objects
     void cleanup();

--- a/VulkanProject/src/scene/Model.cpp
+++ b/VulkanProject/src/scene/Model.cpp
@@ -4,11 +4,11 @@
 #include "asset/modelLoader.hpp"
 
 
-void Model::create(Device device, CommandManager commandManager, std::string modelPath, TextureManager textures,
+void Model::create(Device device, CommandManager commandManager, std::string modelPath, Material material,
 	bool useRawVertexData) {
 
 	this->device = device;
-	this->textures = textures;
+	this->material = material;
 
 	//--------------------------------------------------------
 	// LOAD THE GEOMETRY
@@ -73,5 +73,5 @@ void Model::cleanup() {
 	vkFreeMemory(device.get(), vertexBufferMemory, nullptr);
 	vkDestroyBuffer(device.get(), indexBuffer, nullptr);
 	vkFreeMemory(device.get(), indexBufferMemory, nullptr);
-	textures.cleanup();
+	material.cleanup();
 }

--- a/VulkanProject/src/scene/Model.cpp
+++ b/VulkanProject/src/scene/Model.cpp
@@ -4,7 +4,8 @@
 #include "asset/modelLoader.hpp"
 
 
-void Model::create(Device device, CommandManager commandManager, std::string modelPath, TextureManager textures) {
+void Model::create(Device device, CommandManager commandManager, std::string modelPath, TextureManager textures,
+	bool useRawVertexData) {
 
 	this->device = device;
 	this->textures = textures;
@@ -21,9 +22,12 @@ void Model::create(Device device, CommandManager commandManager, std::string mod
 		VK_BUFFER_USAGE_INDEX_BUFFER_BIT, indexBuffer, indexBufferMemory);
 
 	//--------------------------------------------------------
-	// TRANSFORM AND MODEL MATRICES
-	transform.position = glm::vec3(0.0f, 0.0f, -0.15);
-	transform.scale = glm::vec3(1.2f);
+	// TRANSFORM (if the vertex data will be used with transformations)
+	if (!useRawVertexData) {
+		this->transform = new Transform();
+		this->transform->position = glm::vec3(0.0f, 0.0f, -0.15);
+		this->transform->scale = glm::vec3(1.2f);
+	}
 }
 
 void Model::loadModel(std::string modelPath) {

--- a/VulkanProject/src/scene/Model.cpp
+++ b/VulkanProject/src/scene/Model.cpp
@@ -23,13 +23,7 @@ void Model::create(Device device, CommandManager commandManager, std::string mod
 	//--------------------------------------------------------
 	// TRANSFORM AND MODEL MATRICES
 	transform.position = glm::vec3(0.0f, 0.0f, -0.15);
-	model = glm::mat4(1.0f);
-	// the up vector is in the Z axis
-	model[0] = glm::vec4(transform.right, 0.0f);
-	model[1] = glm::vec4(transform.lookAt, 0.0f);
-	model[2] = glm::vec4(transform.up, 0.0f);
-	model[3] = glm::vec4(transform.position, 1.0f);
-	model = glm::scale(model, glm::vec3(1.2f));
+	transform.scale = glm::vec3(1.2f);
 }
 
 void Model::loadModel(std::string modelPath) {

--- a/VulkanProject/src/scene/Model.hpp
+++ b/VulkanProject/src/scene/Model.hpp
@@ -13,11 +13,11 @@ public:
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// GETTERS AND SETTERS
 
+	Transform getTransform() { return transform; }
 	std::vector<uint32_t> getIndices() { return indices; }
 	VkBuffer getVertexBuffer() { return vertexBuffer; }
 	VkBuffer getIndexBuffer() { return indexBuffer; }
 	TextureManager& getTextures() { return textures; }
-	glm::mat4 getModelMatrix() { return model; }
 
 	void setTextures(TextureManager& textures) { this->textures = std::move(textures); }
 
@@ -46,7 +46,6 @@ private:
 	VkDeviceMemory indexBufferMemory;
 
 	Transform transform;
-	glm::mat4 model;
 
 	TextureManager textures;
 

--- a/VulkanProject/src/scene/Model.hpp
+++ b/VulkanProject/src/scene/Model.hpp
@@ -13,9 +13,13 @@ public:
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// GETTERS AND SETTERS
 
-	Transform getTransform() { return transform; }
+	bool useRawVertexData() { return transform == nullptr; }
+	// Return a copy of the transform. Since the transform can be nullptr, it should be checked with useRawVertexData() method
+	Transform getTransform() { return *transform; }
+
 	std::vector<uint32_t> getIndices() { return indices; }
 	VkBuffer getVertexBuffer() { return vertexBuffer; }
+	
 	VkBuffer getIndexBuffer() { return indexBuffer; }
 	TextureManager& getTextures() { return textures; }
 
@@ -24,8 +28,10 @@ public:
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// METHODS
 
-	// Load a model, create its vertex and index buffer and its textures
-	void create(Device device, CommandManager commandManager, std::string modelPath, TextureManager textures);
+	// Load a model, create its vertex and index buffer and its textures. If useRawVertexData is true then the transform
+	// is not initialized (the shader will use the raw vertex data without transformations)
+	void create(Device device, CommandManager commandManager, std::string modelPath, TextureManager textures,
+		bool useRawVertexData = false);
 
 	// Destroy Vulkan and other objects
 	void cleanup();
@@ -45,7 +51,7 @@ private:
 	VkBuffer indexBuffer;
 	VkDeviceMemory indexBufferMemory;
 
-	Transform transform;
+	Transform* transform = nullptr;
 
 	TextureManager textures;
 

--- a/VulkanProject/src/scene/Model.hpp
+++ b/VulkanProject/src/scene/Model.hpp
@@ -4,7 +4,7 @@
 #include "context/CommandManager.hpp"
 #include "render/vertex/Vertex.hpp"
 #include "Transform.hpp"
-#include "render/uniform/TextureManager.hpp"
+#include "render/uniform/Material.hpp"
 
 
 class Model {
@@ -21,16 +21,16 @@ public:
 	VkBuffer getVertexBuffer() { return vertexBuffer; }
 	
 	VkBuffer getIndexBuffer() { return indexBuffer; }
-	TextureManager& getTextures() { return textures; }
+	Material& getMaterial() { return material; }
 
-	void setTextures(TextureManager& textures) { this->textures = std::move(textures); }
+	void setMaterial(Material& material) { this->material = std::move(material); }
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// METHODS
 
 	// Load a model, create its vertex and index buffer and its textures. If useRawVertexData is true then the transform
 	// is not initialized (the shader will use the raw vertex data without transformations)
-	void create(Device device, CommandManager commandManager, std::string modelPath, TextureManager textures,
+	void create(Device device, CommandManager commandManager, std::string modelPath, Material material,
 		bool useRawVertexData = false);
 
 	// Destroy Vulkan and other objects
@@ -53,7 +53,7 @@ private:
 
 	Transform* transform = nullptr;
 
-	TextureManager textures;
+	Material material;
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// METHODS

--- a/VulkanProject/src/scene/Transform.cpp
+++ b/VulkanProject/src/scene/Transform.cpp
@@ -20,3 +20,19 @@ void Transform::changeOrientation(glm::vec3 newLookAt) {
 
 	changeOrientation(rotationMatrix);
 }
+
+glm::mat4 createModelMatrix(Transform transform) {
+	glm::mat4 model = glm::mat4(1.0f);
+
+	// rotation
+	// the up vector is in the Z axis
+	model[0] = glm::vec4(transform.right, 0.0f);
+	model[1] = glm::vec4(transform.lookAt, 0.0f);
+	model[2] = glm::vec4(transform.up, 0.0f);
+	// translation
+	model[3] = glm::vec4(transform.position, 1.0f);
+	// scale
+	model = model * glm::scale(glm::mat4(1.0f), transform.scale);
+
+	return model;
+}

--- a/VulkanProject/src/scene/Transform.hpp
+++ b/VulkanProject/src/scene/Transform.hpp
@@ -3,11 +3,13 @@
 #include <glm/glm.hpp>
 
 
+// TODO: review the fields (rotation)
 struct Transform {
 	glm::vec3 position;
 	glm::vec3 lookAt;
 	glm::vec3 up;
 	glm::vec3 right;
+	glm::vec3 scale;
 
 	static const glm::vec3 X;
 	static const glm::vec3 Y;
@@ -17,9 +19,12 @@ struct Transform {
 		position(glm::vec3(0.0f)),
 		lookAt(Transform::Y),
 		up(Transform::Z),
-		right(Transform::X)
+		right(Transform::X),
+		scale(glm::vec3(1.0f))
 	{}
 
 	void changeOrientation(glm::mat3 transformation);
 	void changeOrientation(glm::vec3 newLookAt);
 };
+
+glm::mat4 createModelMatrix(Transform transform);


### PR DESCRIPTION
### Description

Update `Model` and `TextureManager` implementation. The latter was renamed to `Material`, being a struct instead of a class.

### Main changes
- Add `glm::vec3 scale` field to `Transform`.
- Move model matrix creation to `Transform`.
- `TextureManager` renamed to `Material`, the manager term was not accurate.
- Add to `Model` creation option to don't use any transformation (`useRawVertexData`, useful for post-processing quads).

### Possible improvements

- Move sampler out of `Material`.
- Decouple texture image creation out of `Material`.